### PR TITLE
Add maybeAdd* APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,47 @@ assert.deepEqual(encodedMap(map), {
 });
 ```
 
+### Smaller Sourcemaps
+
+Not everything needs to be added to a sourcemap, and needless markings can cause signficantly
+larger file sizes. `gen-mapping` exposes `maybeAddSegment`/`maybeAddMapping` APIs that will
+intelligently determine if this marking adds useful information. If not, the marking will be
+skipped.
+
+```typescript
+import { GenMapping, encodedMap, maybeAddMapping } from '@jridgewell/gen-mapping';
+
+const map = new GenMapping();
+
+// Adding a sourceless marking at the beginning of a line isn't useful.
+maybeAddMapping(map, {
+  generated: { line: 1, column: 0 },
+});
+
+// Adding a new source marking is useful.
+maybeAddMapping(map, {
+  generated: { line: 1, column: 0 },
+  source: 'input.js',
+  original: { line: 1, column: 0 },
+});
+
+// But adding another marking pointing to the exact same original location isn't, even if the
+// generated column changed.
+maybeAddMapping(map, {
+  generated: { line: 1, column: 9 },
+  source: 'input.js',
+  original: { line: 1, column: 0 },
+});
+
+assert.deepEqual(encodedMap(map), {
+  version: 3,
+  names: [],
+  sources: ['input.js'],
+  sourcesContent: [null],
+  mappings: 'AAAA',
+});
+```
+
 ## Benchmarks
 
 ```

--- a/src/gen-mapping.ts
+++ b/src/gen-mapping.ts
@@ -303,7 +303,8 @@ export class GenMapping {
       const namesIndex = name ? put(names, name) : -1;
       if (sourcesIndex === sourcesContent.length) sourcesContent[sourcesIndex] = null;
 
-      if (skipable && skipSource(line, index, sourcesIndex, sourceLine, sourceColumn)) return;
+      if (skipable && skipSource(line, index, sourcesIndex, sourceLine, sourceColumn, namesIndex))
+        return;
 
       return insert(
         line,
@@ -374,6 +375,7 @@ function skipSource(
   sourcesIndex: number,
   sourceLine: number,
   sourceColumn: number,
+  namesIndex: number,
 ): boolean {
   // A source/named segment at the start of a line gives position at that genColumn
   if (index === 0) return false;
@@ -384,7 +386,8 @@ function skipSource(
   return (
     sourcesIndex === prev[SOURCES_INDEX] &&
     sourceLine === prev[SOURCE_LINE] &&
-    sourceColumn === prev[SOURCE_COLUMN]
+    sourceColumn === prev[SOURCE_COLUMN] &&
+    namesIndex === (prev.length === 5 ? prev[4] : -1)
   );
 }
 

--- a/src/gen-mapping.ts
+++ b/src/gen-mapping.ts
@@ -161,11 +161,29 @@ export class GenMapping {
 
   static {
     addSegment = (map, genLine, genColumn, source, sourceLine, sourceColumn, name) => {
-      addSegmentInternal(false, map, genLine, genColumn, source, sourceLine, sourceColumn, name);
+      return addSegmentInternal(
+        false,
+        map,
+        genLine,
+        genColumn,
+        source,
+        sourceLine,
+        sourceColumn,
+        name,
+      );
     };
 
     maybeAddSegment = (map, genLine, genColumn, source, sourceLine, sourceColumn, name) => {
-      addSegmentInternal(true, map, genLine, genColumn, source, sourceLine, sourceColumn, name);
+      return addSegmentInternal(
+        true,
+        map,
+        genLine,
+        genColumn,
+        source,
+        sourceLine,
+        sourceColumn,
+        name,
+      );
     };
 
     addMapping = (map, mapping) => {
@@ -287,7 +305,7 @@ export class GenMapping {
 
       if (skipable && skipSource(line, index, sourcesIndex, sourceLine, sourceColumn)) return;
 
-      insert(
+      return insert(
         line,
         index,
         name
@@ -395,7 +413,7 @@ function addMappingInternal<S extends string | null | undefined>(
   }
   const s: string = source;
   assert<Pos>(original);
-  addSegmentInternal(
+  return addSegmentInternal(
     skipable,
     map,
     generated.line - 1,

--- a/test/gen-mapping.test.js
+++ b/test/gen-mapping.test.js
@@ -8,6 +8,7 @@ const {
   allMappings,
   fromMap,
   maybeAddSegment,
+  maybeAddMapping,
 } = require('..');
 const assert = require('assert');
 
@@ -557,7 +558,7 @@ describe('GenMapping', () => {
     });
   });
 
-  describe('maybeAddMapping', () => {
+  describe('maybeAddSegment', () => {
     describe('sourceless segment added afterwards', () => {
       it('skips sourceless segment first on line', () => {
         const map = new GenMapping();
@@ -660,7 +661,12 @@ describe('GenMapping', () => {
         maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
         maybeAddSegment(map, 0, 0, 'foo.js', 0, 0);
 
-        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0], [0, 1, 0, 0]]]);
+        assert.deepEqual(toDecodedMap(map).mappings, [
+          [
+            [0, 0, 0, 0],
+            [0, 1, 0, 0],
+          ],
+        ]);
       });
 
       it('keeps source segment pointing to different source line', () => {
@@ -669,7 +675,12 @@ describe('GenMapping', () => {
         maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
         maybeAddSegment(map, 0, 0, 'input.js', 1, 0);
 
-        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0], [0, 0, 1, 0]]]);
+        assert.deepEqual(toDecodedMap(map).mappings, [
+          [
+            [0, 0, 0, 0],
+            [0, 0, 1, 0],
+          ],
+        ]);
       });
 
       it('keeps source segment pointing to different source column', () => {
@@ -678,7 +689,12 @@ describe('GenMapping', () => {
         maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
         maybeAddSegment(map, 0, 0, 'input.js', 0, 1);
 
-        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0], [0, 0, 0, 1]]]);
+        assert.deepEqual(toDecodedMap(map).mappings, [
+          [
+            [0, 0, 0, 0],
+            [0, 0, 0, 1],
+          ],
+        ]);
       });
 
       it('keeps source segment after matching sourceless segment', () => {
@@ -689,6 +705,68 @@ describe('GenMapping', () => {
         maybeAddSegment(map, 0, 1, 'input.js', 0, 0);
 
         assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0], [1], [1, 0, 0, 0]]]);
+      });
+    });
+  });
+
+  describe('maybeAddMapping', () => {
+    describe('sourceless segment added afterwards', () => {
+      it('skips sourceless segment first on line', () => {
+        const map = new GenMapping();
+
+        maybeAddMapping(map, {
+          generated: { line: 1, column: 1 },
+          source: 'input.js',
+          original: {
+            line: 1,
+            column: 0,
+          },
+        });
+        maybeAddMapping(map, { generated: { line: 2, column: 1 } });
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[1, 0, 0, 0]]]);
+      });
+
+      it('skips equivalent sourceless segment', () => {
+        const map = new GenMapping();
+
+        maybeAddMapping(map, {
+          generated: { line: 1, column: 0 },
+          source: 'input.js',
+          original: {
+            line: 1,
+            column: 0,
+          },
+        });
+        maybeAddMapping(map, { generated: { line: 1, column: 1 } });
+        maybeAddMapping(map, { generated: { line: 1, column: 1 } });
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0], [1]]]);
+      });
+    });
+
+    describe('source segment added afterwards', () => {
+      it('skips equivalent source segment', () => {
+        const map = new GenMapping();
+
+        maybeAddMapping(map, {
+          generated: { line: 1, column: 0 },
+          source: 'input.js',
+          original: {
+            line: 1,
+            column: 0,
+          },
+        });
+        maybeAddMapping(map, {
+          generated: { line: 1, column: 0 },
+          source: 'input.js',
+          original: {
+            line: 1,
+            column: 0,
+          },
+        });
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0]]]);
       });
     });
   });

--- a/test/gen-mapping.test.js
+++ b/test/gen-mapping.test.js
@@ -628,22 +628,60 @@ describe('GenMapping', () => {
         assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0]]]);
       });
 
-      it('skips source segment after matching named segment', () => {
+      it('keeps source segment after matching named segment', () => {
         const map = new GenMapping();
 
         maybeAddSegment(map, 0, 0, 'input.js', 0, 0, 'foo');
         maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
 
-        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0, 0]]]);
+        assert.deepEqual(toDecodedMap(map).mappings, [
+          [
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0],
+          ],
+        ]);
       });
 
-      it('skips named segment after matching source segment', () => {
+      it('keeps runs of source segment after matching named segment', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0, 'foo');
+        maybeAddSegment(map, 0, 1, 'input.js', 0, 0);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [
+          [
+            [0, 0, 0, 0, 0],
+            [1, 0, 0, 0],
+          ],
+        ]);
+      });
+
+      it('keeps named segment after matching source segment', () => {
         const map = new GenMapping();
 
         maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
         maybeAddSegment(map, 0, 0, 'input.js', 0, 0, 'foo');
 
-        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0]]]);
+        assert.deepEqual(toDecodedMap(map).mappings, [
+          [
+            [0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+          ],
+        ]);
+      });
+
+      it('keeps runs of named segment after matching source segment', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+        maybeAddSegment(map, 0, 1, 'input.js', 0, 0, 'foo');
+
+        assert.deepEqual(toDecodedMap(map).mappings, [
+          [
+            [0, 0, 0, 0],
+            [1, 0, 0, 0, 0],
+          ],
+        ]);
       });
 
       it('skips runs of matching source segment', () => {
@@ -662,34 +700,6 @@ describe('GenMapping', () => {
         maybeAddSegment(map, 0, 1, 'input.js', 0, 0, 'foo');
 
         assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0, 0]]]);
-      });
-
-      it('keeps runs of matching source segment to named segment', () => {
-        const map = new GenMapping();
-
-        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
-        maybeAddSegment(map, 0, 1, 'input.js', 0, 0, 'foo');
-
-        assert.deepEqual(toDecodedMap(map).mappings, [
-          [
-            [0, 0, 0, 0],
-            [1, 0, 0, 0, 0],
-          ],
-        ]);
-      });
-
-      it('keeps runs of matching named segment to source segment', () => {
-        const map = new GenMapping();
-
-        maybeAddSegment(map, 0, 0, 'input.js', 0, 0, 'foo');
-        maybeAddSegment(map, 0, 1, 'input.js', 0, 0);
-
-        assert.deepEqual(toDecodedMap(map).mappings, [
-          [
-            [0, 0, 0, 0, 0],
-            [1, 0, 0, 0],
-          ],
-        ]);
       });
 
       it('keeps source segment pointing to different source file', () => {

--- a/test/gen-mapping.test.js
+++ b/test/gen-mapping.test.js
@@ -7,6 +7,7 @@ const {
   toEncodedMap,
   allMappings,
   fromMap,
+  maybeAddSegment,
 } = require('..');
 const assert = require('assert');
 
@@ -142,7 +143,11 @@ describe('GenMapping', () => {
       addSegment(map, 2, 0, 'input.js', 2, 0);
       addSegment(map, 0, 0, 'input.js', 0, 0);
 
-      assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0]], [[0, 0, 1, 0]], [[0, 0, 2, 0]]]);
+      assert.deepEqual(toDecodedMap(map).mappings, [
+        [[0, 0, 0, 0]],
+        [[0, 0, 1, 0]],
+        [[0, 0, 2, 0]],
+      ]);
     });
 
     it('sorts generated column', () => {
@@ -160,7 +165,7 @@ describe('GenMapping', () => {
       ]);
     });
 
-    it('sorts source index', () => {
+    it('postfix sorts source index', () => {
       const map = new GenMapping();
 
       addSegment(map, 1, 0, 'foo.js', 0, 0);
@@ -169,14 +174,14 @@ describe('GenMapping', () => {
 
       assert.deepEqual(toDecodedMap(map).mappings, [
         [
-          [0, 0, 0, 0],
           [0, 1, 0, 0],
+          [0, 0, 0, 0],
         ],
         [[0, 0, 0, 0]],
       ]);
     });
 
-    it('sorts source line', () => {
+    it('postfix sorts source line', () => {
       const map = new GenMapping();
 
       addSegment(map, 0, 0, 'input.js', 1, 0);
@@ -185,14 +190,14 @@ describe('GenMapping', () => {
 
       assert.deepEqual(toDecodedMap(map).mappings, [
         [
-          [0, 0, 0, 0],
           [0, 0, 1, 0],
           [0, 0, 2, 0],
+          [0, 0, 0, 0],
         ],
       ]);
     });
 
-    it('sorts source column', () => {
+    it('postfix sorts source column', () => {
       const map = new GenMapping();
 
       addSegment(map, 0, 0, 'input.js', 0, 1);
@@ -201,14 +206,14 @@ describe('GenMapping', () => {
 
       assert.deepEqual(toDecodedMap(map).mappings, [
         [
-          [0, 0, 0, 0],
           [0, 0, 0, 1],
           [0, 0, 0, 2],
+          [0, 0, 0, 0],
         ],
       ]);
     });
 
-    it('sorts name index', () => {
+    it('postfix sorts name index', () => {
       const map = new GenMapping();
 
       addSegment(map, 1, 0, 'input.js', 0, 0, 'foo');
@@ -217,32 +222,32 @@ describe('GenMapping', () => {
 
       assert.deepEqual(toDecodedMap(map).mappings, [
         [
-          [0, 0, 0, 0, 0],
           [0, 0, 0, 0, 1],
+          [0, 0, 0, 0, 0],
         ],
         [[0, 0, 0, 0, 0]],
       ]);
     });
 
-    it('sorts sourceless segment before source segment', () => {
+    it('postfix sorts sourceless segment after source segment', () => {
       const map = new GenMapping();
 
       addSegment(map, 0, 0, 'input.js', 0, 0);
       addSegment(map, 0, 0);
 
-      assert.deepEqual(toDecodedMap(map).mappings, [[[0], [0, 0, 0, 0]]]);
+      assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0], [0]]]);
     });
 
-    it('sorts sourceless segment before named segment', () => {
+    it('postfix sorts sourceless segment after named segment', () => {
       const map = new GenMapping();
 
       addSegment(map, 0, 0, 'input.js', 0, 0, 'foo');
       addSegment(map, 0, 0);
 
-      assert.deepEqual(toDecodedMap(map).mappings, [[[0], [0, 0, 0, 0, 0]]]);
+      assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0, 0], [0]]]);
     });
 
-    it('sorts source segment before named segment', () => {
+    it('postfix sorts source segment after named segment', () => {
       const map = new GenMapping();
 
       addSegment(map, 0, 0, 'input.js', 0, 0, 'foo');
@@ -250,8 +255,8 @@ describe('GenMapping', () => {
 
       assert.deepEqual(toDecodedMap(map).mappings, [
         [
-          [0, 0, 0, 0],
           [0, 0, 0, 0, 0],
+          [0, 0, 0, 0],
         ],
       ]);
     });
@@ -266,7 +271,7 @@ describe('GenMapping', () => {
       assert.deepEqual(toDecodedMap(map).mappings, [[[0], [0]], [[0]]]);
     });
 
-    it('skips equivalent source segment', () => {
+    it('keeps equivalent source segment', () => {
       const map = new GenMapping();
 
       addSegment(map, 0, 0, 'input.js', 0, 0);
@@ -549,6 +554,142 @@ describe('GenMapping', () => {
       const map = fromMap(input);
 
       assert.deepEqual(toDecodedMap(map).mappings, [[[1, 0, 2, 3, 0]]]);
+    });
+  });
+
+  describe('maybeAddMapping', () => {
+    describe('sourceless segment added afterwards', () => {
+      it('skips sourceless segment first on line', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 1, 'input.js', 0, 0);
+        maybeAddSegment(map, 1, 1);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[1, 0, 0, 0]]]);
+      });
+
+      it('skips sourceless segment sorted first in line', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 1, 'input.js', 0, 0);
+        maybeAddSegment(map, 0, 0);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[1, 0, 0, 0]]]);
+      });
+
+      it('skips equivalent sourceless segment', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+        maybeAddSegment(map, 0, 1);
+        maybeAddSegment(map, 0, 1);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0], [1]]]);
+      });
+
+      it('skips runs of sourceless segment', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+        maybeAddSegment(map, 0, 1);
+        maybeAddSegment(map, 0, 2);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0], [1]]]);
+      });
+
+      it('does not skip sourcless segment sorted before sourceless segment', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+        maybeAddSegment(map, 0, 2);
+        maybeAddSegment(map, 0, 1);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0], [1], [2]]]);
+      });
+
+      it('does not skip sourcless segment matching source segment', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+        maybeAddSegment(map, 0, 0);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0], [0]]]);
+      });
+    });
+
+    describe('source segment added afterwards', () => {
+      it('skips equivalent source segment', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0]]]);
+      });
+
+      it('skips source segment after matching named segment', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0, 'foo');
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0, 0]]]);
+      });
+
+      it('skips named segment after matching source segment', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0, 'foo');
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0]]]);
+      });
+
+      it('skips runs of matching source segment', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+        maybeAddSegment(map, 0, 1, 'input.js', 0, 0);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0]]]);
+      });
+
+      it('keeps source segment pointing to different source file', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+        maybeAddSegment(map, 0, 0, 'foo.js', 0, 0);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0], [0, 1, 0, 0]]]);
+      });
+
+      it('keeps source segment pointing to different source line', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+        maybeAddSegment(map, 0, 0, 'input.js', 1, 0);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0], [0, 0, 1, 0]]]);
+      });
+
+      it('keeps source segment pointing to different source column', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 1);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0], [0, 0, 0, 1]]]);
+      });
+
+      it('keeps source segment after matching sourceless segment', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+        maybeAddSegment(map, 0, 1);
+        maybeAddSegment(map, 0, 1, 'input.js', 0, 0);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0], [1], [1, 0, 0, 0]]]);
+      });
     });
   });
 });

--- a/test/gen-mapping.test.js
+++ b/test/gen-mapping.test.js
@@ -655,6 +655,43 @@ describe('GenMapping', () => {
         assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0]]]);
       });
 
+      it('skips runs of matching named segment', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0, 'foo');
+        maybeAddSegment(map, 0, 1, 'input.js', 0, 0, 'foo');
+
+        assert.deepEqual(toDecodedMap(map).mappings, [[[0, 0, 0, 0, 0]]]);
+      });
+
+      it('keeps runs of matching source segment to named segment', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0);
+        maybeAddSegment(map, 0, 1, 'input.js', 0, 0, 'foo');
+
+        assert.deepEqual(toDecodedMap(map).mappings, [
+          [
+            [0, 0, 0, 0],
+            [1, 0, 0, 0, 0],
+          ],
+        ]);
+      });
+
+      it('keeps runs of matching named segment to source segment', () => {
+        const map = new GenMapping();
+
+        maybeAddSegment(map, 0, 0, 'input.js', 0, 0, 'foo');
+        maybeAddSegment(map, 0, 1, 'input.js', 0, 0);
+
+        assert.deepEqual(toDecodedMap(map).mappings, [
+          [
+            [0, 0, 0, 0, 0],
+            [1, 0, 0, 0],
+          ],
+        ]);
+      });
+
       it('keeps source segment pointing to different source file', () => {
         const map = new GenMapping();
 


### PR DESCRIPTION
These APIs will skip useless markings. 

Examples of custom code that this will eliminate:
- https://github.com/ampproject/remapping/blob/cb14ea819ead6c73e92fea4414dfcabebf86ce69/src/source-map-tree.ts#L118-L123
- https://github.com/babel/babel/blob/c90add779ae6f096962bf0ec1add08a6893853f2/packages/babel-generator/src/source-map.ts#L84-L101