### PR TITLE
[meta] fix "exports" for node 13.0-13.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,15 @@
   "module": "dist/gen-mapping.mjs",
   "typings": "dist/types/gen-mapping.d.ts",
   "exports": {
-    ".": {
-      "types": "./dist/types/gen-mapping.d.ts",
-      "browser": "./dist/gen-mapping.umd.js",
-      "require": "./dist/gen-mapping.umd.js",
-      "import": "./dist/gen-mapping.mjs"
-    },
+    ".": [
+      {
+        "types": "./dist/types/gen-mapping.d.ts",
+        "browser": "./dist/gen-mapping.umd.js",
+        "require": "./dist/gen-mapping.umd.js",
+        "import": "./dist/gen-mapping.mjs"
+      },
+      "./dist/gen-mapping.umd.js"
+    ],
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
`engines.node` explicitly says ">= 6", which includes node 13.0-13.6, which is broken without this change.

This came up because `@babel/generator` now depends on this package.